### PR TITLE
Feat: add error handling

### DIFF
--- a/app/constant.ts
+++ b/app/constant.ts
@@ -1,0 +1,10 @@
+/**
+ * @see https://developer.mozilla.org/ja/docs/Web/HTTP/Status
+ */
+export const HTTP_ERROR_STATUS = {
+  BAD_REQUEST_400: 400,
+  UNAUTHORIZED_401: 401,
+  FORBIDDEN_403: 403,
+  NOT_FOUND_404: 404,
+  INTERNAL_SERVER_ERROR: 500,
+} as const satisfies Record<string, number>;

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -5,9 +5,11 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
+  useRouteError,
 } from "@remix-run/react";
-
 import "./tailwind.css";
+import { useEffect } from "react";
+import { getErrorStatus } from "./utils/errors";
 
 export const links: LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -42,4 +44,14 @@ export function Layout({ children }: { children: React.ReactNode }) {
 
 export default function App() {
   return <Outlet />;
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const status = getErrorStatus(error);
+
+  useEffect(() => {
+    window.location.replace(`/error/${status}/`);
+  });
+  return null;
 }

--- a/app/routes/error+/$status.tsx
+++ b/app/routes/error+/$status.tsx
@@ -1,0 +1,21 @@
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { redirect, useLoaderData } from "@remix-run/react";
+import type { FunctionComponent } from "react";
+import { isHttpErrorStatus } from "~/utils/errors";
+
+export const loader = ({ params }: LoaderFunctionArgs) => {
+  const errorStatus = Number(params.status);
+
+  if (!isHttpErrorStatus(errorStatus)) {
+    return redirect("/error/404/");
+  }
+
+  return errorStatus;
+};
+
+const Index: FunctionComponent = () => {
+  const data = useLoaderData<typeof loader>();
+  return <div>{`${data.toString()}エラーだよ`}</div>;
+};
+
+export default Index;

--- a/app/utils/errors.ts
+++ b/app/utils/errors.ts
@@ -1,0 +1,25 @@
+import { isRouteErrorResponse } from "@remix-run/react";
+import { HTTP_ERROR_STATUS } from "~/constant";
+
+type HttpErrorStatus =
+  (typeof HTTP_ERROR_STATUS)[keyof typeof HTTP_ERROR_STATUS];
+
+export const isHttpErrorStatus = (
+  status: number,
+): status is HttpErrorStatus => {
+  return Object.values(HTTP_ERROR_STATUS).some(
+    (errorCode) => errorCode === status,
+  );
+};
+
+export const getErrorStatus = (error: unknown): HttpErrorStatus => {
+  if (isRouteErrorResponse(error)) {
+    const status = error.status;
+    if (isHttpErrorStatus(status)) {
+      return status;
+    }
+  }
+
+  // 例外はすべて500エラー
+  return HTTP_ERROR_STATUS.INTERNAL_SERVER_ERROR;
+};


### PR DESCRIPTION
## 概要
- サンプルエラーページの追加
- ErrorBoundaryの追加

### 備考
アプリケーション内のthrowを拾ってエラーページに遷移する処理を追加。
テストケースはvitest導入後に追加