### PR TITLE
機能追加: OpenSearchAPIをTypeScriptで扱う機能を追加

### DIFF
--- a/modules/drivers/ndlsearch/OpenSearchAPI/constant.ts
+++ b/modules/drivers/ndlsearch/OpenSearchAPI/constant.ts
@@ -1,0 +1,106 @@
+/**
+ * ## メディアタイプ一覧
+ * @see https://ndlsearch.ndl.go.jp/file/help/api/specifications/ndlsearch_api_ap2_20240401.pdf
+ */
+export const MEDIA_TYPES_INFO = {
+  booklet: { name: "紙", description: "資料形態が”紙”であるメタデータ" },
+  micro: {
+    name: "マイクロ",
+    description: "資料形態が”マイクロ”であるメタデータ",
+  },
+  media: {
+    name: "記録メディア",
+    description: "資料形態が”記録メディア”であるメタデータ",
+  },
+  digital: {
+    name: "デジタル",
+    description: "資料形態が”デジタル”であるメタデータ",
+  },
+  books: { name: "図書", description: "資料種別が”図書”であるメタデータ" },
+  periodicals: {
+    name: "雑誌",
+    description: "資料種別が”雑誌”であるメタデータ",
+  },
+  articles: { name: "記事", description: "資料種別が”記事”であるメタデータ" },
+  newspapers: { name: "新聞", description: "資料種別が”新聞”であるメタデータ" },
+  oldmaterials: {
+    name: "和古書・漢籍",
+    description: "資料種別が”和古書・漢籍”であるメタデータ",
+  },
+  maps: { name: "地図", description: "資料種別が”地図”であるメタデータ" },
+  electronic: {
+    name: "電子資料",
+    description: "資料種別が”電子資料”であるメタデータ",
+  },
+  video: {
+    name: "映像資料",
+    description: "資料種別が”映像資料”であるメタデータ",
+  },
+  audio: {
+    name: "録音資料",
+    description: "資料種別が”録音資料”であるメタデータ",
+  },
+  online: {
+    name: "電子資料・電子雑誌",
+    description: "資料種別が”電子書籍・電子雑誌”であるメタデータ",
+  },
+  doctoral: {
+    name: "博士論文",
+    description: "資料種別が”博士論文”であるメタデータ",
+  },
+  reports: {
+    name: "規格・テクニカルリポート類",
+    description: "資料種別が”規格・テクニカルリポート類”であるメタデータ",
+  },
+  web: {
+    name: "webサイト",
+    description: "資料種別が”webサイト”であるメタデータ",
+  },
+  scores: { name: "楽譜", description: "資料種別が”楽譜”であるメタデータ" },
+  manuscripts: {
+    name: "文書・図像類",
+    description: "資料種別が”文書・図像類”であるメタデータ",
+  },
+  children: {
+    name: "児童書",
+    description: "コレクションが”児童書”であるメタデータ",
+  },
+  repository: {
+    name: "リポジトリ収録資料",
+    description: "コレクションが”リポジトリ収録資料”であるメタデータ",
+  },
+  mina: {
+    name: "障害者（全体）",
+    description: "コレクションが”障害者向け資料”であるメタデータ",
+  },
+  "mina-daisy": {
+    name: "障害者DAISY",
+    description:
+      "コレクションが”障害者向け資料”であり、資料形態が”DAISY”であるメタデータ",
+  },
+  "mina-audio": {
+    name: "録音資料",
+    description:
+      "コレクションが”障害者向け資料”であり、資料形態が”録音資料”であるメタデータ",
+  },
+  "mina-braille": {
+    name: "点字資料",
+    description:
+      "コレクションが”障害者向け資料”であり、資料形態が”点字資料”であるメタデータ",
+  },
+  "mina-text": {
+    name: "テキストデータ",
+    description:
+      "コレクションが”障害者向け資料”であり、資料形態が”テキストデータ”であるメタデータ",
+  },
+  "mina-video": {
+    name: "映像資料",
+    description:
+      "コレクションが”障害者向け資料”であり、資料形態が”映像資料”であるメタデータ",
+  },
+  "mina-booklet": {
+    name: "冊子体資料",
+    description:
+      "コレクションが”障害者向け資料”であり、資料形態が”冊子体資料”であるメタデータ",
+  },
+} as const satisfies Record<string, { name: string; description: string }>;

--- a/modules/drivers/ndlsearch/OpenSearchAPI/index.ts
+++ b/modules/drivers/ndlsearch/OpenSearchAPI/index.ts
@@ -1,0 +1,23 @@
+import type { OpenSearchOptions, OpenSearchResponseType } from "./types";
+import { parseOpenSearchXml } from "./utils/parse";
+import { buildQuery } from "./utils/query";
+import { validationOpenSearchSchema } from "./utils/validation";
+
+const OPEN_SEARCH_URL = "https://ndlsearch.ndl.go.jp/api/opensearch" as const;
+
+/**
+ * ## Open Search API検索実行
+ * 検索結果のxmlはRSS2.0形式で返却される為、それに準拠したパースを行う。
+ */
+export const OpenSearchAPI = async (
+  querys: OpenSearchOptions,
+): Promise<OpenSearchResponseType> => {
+  const query = buildQuery(querys);
+  const req = `${OPEN_SEARCH_URL}?${query}`;
+
+  const res = await fetch(req);
+  const xml = await res.text();
+
+  const parsedObj = parseOpenSearchXml(xml);
+  return validationOpenSearchSchema(parsedObj);
+};

--- a/modules/drivers/ndlsearch/OpenSearchAPI/schema.ts
+++ b/modules/drivers/ndlsearch/OpenSearchAPI/schema.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+const openSearchDcIdentifierSchema = z.object({
+  "#text": z.union([z.string(), z.number()]),
+  "@_xsi:type": z.string(),
+});
+
+const openSearchRdfSeeAlsoSchema = z.object({
+  "@_rdf:resource": z.string(),
+});
+
+const openSearchItemSchema = z.object({
+  title: z.string(),
+  link: z.string(),
+  description: z.string(),
+  author: z.string(),
+  category: z.union([z.string(), z.array(z.string())]),
+  "dc:title": z.string(),
+  "dc:creator": z.union([z.string(), z.array(z.string())]).optional(),
+  "dcndl:volume": z.number().optional(),
+  "dc:publisher": z.union([z.string(), z.array(z.string())]).optional(),
+  "dc:identifier": z
+    .union([
+      openSearchDcIdentifierSchema,
+      z.array(openSearchDcIdentifierSchema),
+    ])
+    .optional(),
+  "rdfs:seeAlso": z
+    .union([openSearchRdfSeeAlsoSchema, z.array(openSearchRdfSeeAlsoSchema)])
+    .optional(),
+});
+
+export const openSearchResponseSchema = z.object({
+  rss: z.object({
+    channel: z.object({
+      title: z.string(),
+      item: z.union([openSearchItemSchema, z.array(openSearchItemSchema)]),
+      description: z.string(),
+      language: z.string(),
+      link: z.string(),
+      "openSearch:totalResults": z.number(),
+      "openSearch:startIndex": z.number(),
+      "openSearch:itemsPerPage": z.number(),
+    }),
+  }),
+});

--- a/modules/drivers/ndlsearch/OpenSearchAPI/types.ts
+++ b/modules/drivers/ndlsearch/OpenSearchAPI/types.ts
@@ -1,0 +1,68 @@
+import type { z } from "zod";
+import type { MEDIA_TYPES_INFO } from "./constant";
+import type { openSearchResponseSchema } from "./schema";
+
+export type MediaType = keyof typeof MEDIA_TYPES_INFO;
+
+/**
+ * ## NDC(書籍分類)
+ * @see https://www.library.metro.tokyo.lg.jp/support_school/research/for_study/report_guide/tool/ndc/index.html
+ */
+export enum NDC {
+  /** 総記 */
+  GeneralWorks = 0,
+  /** 哲学 */
+  Philosophy = 1,
+  /** 歴史 */
+  History = 2,
+  /** 社会科学 */
+  SocialSciences = 3,
+  /** 自然科学 */
+  NaturalSciences = 4,
+  /** 技術 */
+  Technology = 5,
+  /** 産業 */
+  Industry = 6,
+  /** 芸術 */
+  Arts = 7,
+  /** 言語 */
+  Language = 8,
+  /** 文学 */
+  Literature = 9,
+}
+
+/**
+ * ## Open Search API - 検索オプション
+ * 外部提供インタフェース仕様書の12P参照
+ * @see https://ndlsearch.ndl.go.jp/file/help/api/specifications/ndlsearch_api_20240712.pdf
+ */
+export interface OpenSearchOptions {
+  /**データプロバイダ ID、データグループ ID、コレクションコード、AcessRights */
+  dpid?: string | string[];
+  /** すべての項目を対象に検索 */
+  any?: string;
+  /** タイトル(部分一致・複数可) */
+  title?: string | string[];
+  /** 作成者(部分一致・複数可) */
+  creator?: string | string[];
+  /** 出版者(部分一致・複数可) */
+  publisher?: string | string[];
+  /** デジタル化した製作者(部分一致・複数可) */
+  digitizedPublisher?: string | string[];
+  /** 分類(NDC, NDLC)(前方一致) */
+  ndc?: NDC;
+  /** 開始出版年月日 */
+  from?: Date;
+  /** 終了出版年月日 */
+  until?: Date;
+  /** 出力レコード上限値（省略時は200とする。max=500） */
+  cnt?: number;
+  /** レコード取得開始位置（省略時は1とする）  */
+  idx?: number;
+  /** ISBN(完全一致または前方一致) */
+  isbn?: string;
+  /** メディアタイプ(完全一致・複数可) */
+  mediatype?: MediaType | MediaType[];
+}
+
+export type OpenSearchResponseType = z.infer<typeof openSearchResponseSchema>;

--- a/modules/drivers/ndlsearch/OpenSearchAPI/utils/parse.ts
+++ b/modules/drivers/ndlsearch/OpenSearchAPI/utils/parse.ts
@@ -1,0 +1,18 @@
+import { XMLParser } from "fast-xml-parser";
+
+const xmlParser = new XMLParser({
+  ignoreAttributes: false,
+  trimValues: true,
+  parseAttributeValue: true,
+  numberParseOptions: {
+    hex: false,
+    leadingZeros: false,
+  },
+});
+
+/**
+ * ### NDL API (OpenSearch) のレスポンスをパース
+ * xmlはRSS2.0形式で返却される為、それに準拠したパースを行う。
+ * @see https://hail2u.net/documents/rss20notes.html#channel_element
+ */
+export const parseOpenSearchXml = (xml: string) => xmlParser.parse(xml);

--- a/modules/drivers/ndlsearch/OpenSearchAPI/utils/query.test.ts
+++ b/modules/drivers/ndlsearch/OpenSearchAPI/utils/query.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import { NDC, type OpenSearchOptions } from "../types";
+import { buildQuery } from "./query";
+
+type TestPattern = {
+  patternName: string;
+  propsPattern: OpenSearchOptions;
+  expected: string;
+};
+
+const testPatterns = [
+  {
+    patternName: "タイトルだけのクエリ",
+    propsPattern: { title: "夏目漱石" },
+    expected: "title=%E5%A4%8F%E7%9B%AE%E6%BC%B1%E7%9F%B3",
+  },
+  {
+    patternName: "日付だけのクエリ",
+    propsPattern: { until: new Date("2024/01/01") },
+    expected: "until=2024-01-01",
+  },
+  {
+    patternName: "タイトルを複数指定したクエリ",
+    propsPattern: { title: ["夏目漱石", "マリーアントワネット"] },
+    expected:
+      "title=%E5%A4%8F%E7%9B%AE%E6%BC%B1%E7%9F%B3&title=%E3%83%9E%E3%83%AA%E3%83%BC%E3%82%A2%E3%83%B3%E3%83%88%E3%83%AF%E3%83%8D%E3%83%83%E3%83%88",
+  },
+  {
+    patternName:
+      "タイトルに「マリーアントワネット」を含み、かつ分類（NDC）が「2（歴史）」",
+    propsPattern: {
+      cnt: 10,
+      title: "マリーアントワネット",
+      ndc: NDC.History,
+    },
+    expected:
+      "cnt=10&title=%E3%83%9E%E3%83%AA%E3%83%BC%E3%82%A2%E3%83%B3%E3%83%88%E3%83%AF%E3%83%8D%E3%83%83%E3%83%88&ndc=2",
+  },
+] as const satisfies TestPattern[];
+
+describe("BuildQuery() testing", () => {
+  test.each(testPatterns)(
+    "正常系: $patternName",
+    ({ propsPattern, expected }) => {
+      expect(buildQuery(propsPattern)).toEqual(expected);
+    },
+  );
+});

--- a/modules/drivers/ndlsearch/OpenSearchAPI/utils/query.ts
+++ b/modules/drivers/ndlsearch/OpenSearchAPI/utils/query.ts
@@ -1,0 +1,50 @@
+import type { OpenSearchOptions } from "../types";
+
+const isString = (value: unknown): value is string => {
+  return typeof value === "string";
+};
+
+const isNumber = (value: unknown): value is number => {
+  return typeof value === "number";
+};
+
+const formatDate = (date: Date): string => {
+  return date
+    .toLocaleDateString("ja-JP", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    })
+    .replaceAll("/", "-");
+};
+
+/**
+ * ## 検索クエリ作成
+ */
+export const buildQuery = (querys: OpenSearchOptions): string => {
+  const searchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(querys)) {
+    if (isString(value)) {
+      searchParams.append(key, value);
+    }
+
+    if (isNumber(value)) {
+      searchParams.append(key, String(value));
+    }
+
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        if (isString(v)) {
+          searchParams.append(key, v);
+        }
+      }
+    }
+
+    if (value instanceof Date) {
+      searchParams.append(key, formatDate(value));
+    }
+  }
+
+  return searchParams.toString();
+};

--- a/modules/drivers/ndlsearch/OpenSearchAPI/utils/validation.ts
+++ b/modules/drivers/ndlsearch/OpenSearchAPI/utils/validation.ts
@@ -1,0 +1,12 @@
+import { openSearchResponseSchema } from "../schema";
+import type { OpenSearchResponseType } from "../types";
+
+/**
+ * ### パースされたオブジェクトをバリデーションする
+ * @return OpenSearchResponseType
+ */
+export const validationOpenSearchSchema = (
+  xml: unknown,
+): OpenSearchResponseType => {
+  return openSearchResponseSchema.parse(xml);
+};

--- a/modules/drivers/ndlsearch/index.ts
+++ b/modules/drivers/ndlsearch/index.ts
@@ -1,0 +1,3 @@
+// OpenSearchAPI
+export * from "./OpenSearchAPI/types";
+export { OpenSearchAPI } from "./OpenSearchAPI";

--- a/modules/drivers/ndlsearch/readme.md
+++ b/modules/drivers/ndlsearch/readme.md
@@ -1,0 +1,13 @@
+# 国立国会図書館のSearch API
+ndlsearchをTypeScriptで扱えるようにする。
+パッケージとして分離してもいいかも。
+参考: https://ndlsearch.ndl.go.jp/help/api/specifications
+
+## 機能
+- 検索用API
+  - OpenSearchAPI
+  - ~~OpenURL~~
+  - ~~SRU~~
+- ~~ハーベスト用API~~
+  - ~~OAI-PMH~~
+- ~~書影API~~

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@remix-run/node": "^2.15.0",
     "@remix-run/react": "^2.15.0",
     "@remix-run/serve": "^2.15.0",
+    "fast-xml-parser": "^4.5.0",
     "isbot": "^4.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "fast-xml-parser": "^4.5.0",
     "isbot": "^4.1.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5997,6 +5997,11 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
+zod@^3.24.1:
+  version "3.24.1"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.24.1.tgz#27445c912738c8ad1e9de1bea0359fa44d9d35ee"
+  integrity sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==
+
 zwitch@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2871,6 +2871,13 @@ fast-glob@^3.3.2:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-xml-parser@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz#2882b7d01a6825dfdf909638f2de0256351def37"
+  integrity sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==
+  dependencies:
+    strnum "^1.0.5"
+
 fastq@^1.6.0:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.17.1.tgz#2a523f07a4e7b1e81a42b91b8bf2254107753b47"
@@ -5363,6 +5370,11 @@ strip-indent@^4.0.0:
   integrity sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==
   dependencies:
     min-indent "^1.0.1"
+
+strnum@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
 style-to-object@^0.4.1:
   version "0.4.4"


### PR DESCRIPTION
## 概要
OpenSearchAPIをTypeScriptで扱う機能を追加

### 経緯
練習用アプリとして書籍管理を行うシステムを作りたいと思った。
とりあえずTypesScriptでOpenSearchAPIを扱えるようにしたいので、Driversとして追加しておく。
独立性を担保するためにも、パッケージごと分けて作成してもいいかもしれない。というか気が向いたらそうする。